### PR TITLE
Adding Datagen for Ores

### DIFF
--- a/src/main/java/com/lightning/northstar/content/NorthstarBiomes.java
+++ b/src/main/java/com/lightning/northstar/content/NorthstarBiomes.java
@@ -1,0 +1,57 @@
+package com.lightning.northstar.content;
+
+import com.lightning.northstar.Northstar;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.biome.Biome;
+
+public class NorthstarBiomes {
+    public static final ResourceKey<Biome> LUNAR_ASURINE_CAVES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_asurine_caves"));
+    public static final ResourceKey<Biome> LUNAR_COOLED_LAVA_CAVE =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_cooled_lava_cave"));
+    public static final ResourceKey<Biome> LUNAR_CRATER_FIELDS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_crater_fields"));
+    public static final ResourceKey<Biome> LUNAR_GLOWSTONE_CAVERN =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_glowstone_cavern"));
+    public static final ResourceKey<Biome> LUNAR_HILLS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_hills"));
+    public static final ResourceKey<Biome> LUNAR_ICE_CAVES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_ice_caves"));
+    public static final ResourceKey<Biome> LUNAR_PLAINS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("lunar_plains"));
+    public static final ResourceKey<Biome> MARTIAN_CRIMSITE_CAVERNS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("martian_crimsite_caverns"));
+    public static final ResourceKey<Biome> MARTIAN_DUNES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("martian_dunes"));
+    public static final ResourceKey<Biome> MARTIAN_HIGH_LANDS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("martian_highlands"));
+    public static final ResourceKey<Biome> MARTIAN_MAGMATIC_CAVERNS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("martian_magmatic_caverns"));
+    public static final ResourceKey<Biome> MARTIAN_OVERGROWN_CAVERNS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("martian_overgrown_caverns"));
+    public static final ResourceKey<Biome> MARTIAN_PEAKS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("martian_peaks"));
+    public static final ResourceKey<Biome> MERCURY_BASINS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("mercury_basins"));
+    public static final ResourceKey<Biome> MERCURY_HILLS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("mercury_hills"));
+    public static final ResourceKey<Biome> MERCURY_ICY_CAVES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("mercury_icy_caverns"));
+    public static final ResourceKey<Biome> MERCURY_MAGMATIC_CAVERNS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("mercury_magmatic_caverns"));
+    public static final ResourceKey<Biome> VENUS_FUNGAL_CAVES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("venus_fungal_caverns"));
+    public static final ResourceKey<Biome> VENUS_FUNGAL_FOREST =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("venus_fungal_forest"));
+    public static final ResourceKey<Biome> VENUS_LAVA_CAVES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("venus_lava_caves"));
+    public static final ResourceKey<Biome> VENUS_SULFURIC_CAVERNS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("venus_sulfuric_caverns"));
+    public static final ResourceKey<Biome> VENUSIAN_PLAINS =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("venusian_plains"));
+    public static final ResourceKey<Biome> VENUSIAN_WASTES =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("venusian_wastes"));
+    public static final ResourceKey<Biome> VOID =
+        ResourceKey.create(Registries.BIOME, Northstar.asResource("void"));
+}

--- a/src/main/java/com/lightning/northstar/content/NorthstarBlocks.java
+++ b/src/main/java/com/lightning/northstar/content/NorthstarBlocks.java
@@ -31,7 +31,7 @@ import com.lightning.northstar.block.tech.temperature_regulator.TemperatureRegul
 import com.lightning.northstar.block.tech.temperature_regulator.TemperatureRegulatorMovingInteractionBehaviour;
 import com.lightning.northstar.content.NorthstarTags.NorthstarBlockTags;
 import com.lightning.northstar.content.NorthstarTags.NorthstarItemTags;
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import com.lightning.northstar.util.NorthstarDataGenHelper;
 import com.lightning.northstar.world.features.grower.ArgyreSaplingTreeGrower;
 import com.lightning.northstar.world.features.grower.CoilerTreeGrower;

--- a/src/main/java/com/lightning/northstar/data/NorthstarDataGen.java
+++ b/src/main/java/com/lightning/northstar/data/NorthstarDataGen.java
@@ -6,6 +6,9 @@ import com.lightning.northstar.advancements.NorthstarAdvancements;
 import com.lightning.northstar.content.NorthstarDamageTypes;
 import com.lightning.northstar.content.NorthstarRegistries;
 import com.lightning.northstar.data.recipe.*;
+import com.lightning.northstar.data.worldgen.NorthstarBiomeProvider;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarPlacedFeatures;
 import com.simibubi.create.foundation.utility.FilesHelper;
 import com.tterrag.registrate.providers.ProviderType;
 import net.minecraft.core.HolderLookup;
@@ -38,10 +41,12 @@ public class NorthstarDataGen {
         Northstar.REGISTRATE.addDataGenerator(ProviderType.LANG, provider -> provideDefaultLang("base", provider::add));
 
         RegistrySetBuilder builder = new RegistrySetBuilder()
-                // TODO: those don't match the existing ones, which one are the real ones?
-                //.add(Registries.CONFIGURED_FEATURE, NorthstarConfiguredFeatures::bootstrap)
+                .add(Registries.CONFIGURED_FEATURE, NorthstarConfiguredFeatures::bootstrap)
+                .add(Registries.BIOME, NorthstarBiomeProvider::bootstrap)
+                .add(Registries.PLACED_FEATURE, NorthstarPlacedFeatures::bootstrap)
                 .add(Registries.DAMAGE_TYPE, NorthstarDamageTypes::bootstrap)
                 .add(NorthstarRegistries.FUEL, NorthstarFuelTypeGen::bootstrap);
+
 
         DatapackBuiltinEntriesProvider provider = new DatapackBuiltinEntriesProvider(output, lookupProvider, builder, Set.of(Northstar.MOD_ID));
         generator.addProvider(event.includeServer(), provider);

--- a/src/main/java/com/lightning/northstar/data/worldgen/NorthstarBiomeProvider.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/NorthstarBiomeProvider.java
@@ -1,60 +1,18 @@
 package com.lightning.northstar.data.worldgen;
 
-import com.lightning.northstar.content.NorthstarBiomes;
-import com.lightning.northstar.content.NorthstarEntityTypes;
-import net.minecraft.core.HolderGetter;
-import net.minecraft.core.registries.Registries;
+import com.lightning.northstar.data.worldgen.biomes.LunarBiomes;
+import com.lightning.northstar.data.worldgen.biomes.MarsBiomes;
+import com.lightning.northstar.data.worldgen.biomes.MercuryBiomes;
+import com.lightning.northstar.data.worldgen.biomes.VenusBiomes;
 import net.minecraft.data.worldgen.BootstapContext;
-import net.minecraft.data.worldgen.Carvers;
-import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeGenerationSettings;
-import net.minecraft.world.level.biome.BiomeSpecialEffects;
-import net.minecraft.world.level.biome.MobSpawnSettings;
-import net.minecraft.world.level.levelgen.GenerationStep;
-import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
-import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
 public class NorthstarBiomeProvider {
 
     public static void bootstrap(BootstapContext<Biome> context) {
-        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
-        HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
-
-        BiomeSpecialEffects effects = new BiomeSpecialEffects.Builder()
-                .skyColor(0)
-                .fogColor(0)
-                .waterColor(4159204)
-                .waterFogColor(329011)
-                .build();
-
-        MobSpawnSettings spawns = new MobSpawnSettings.Builder()
-                .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_LUNARGRADE.get(), 40, 1, 4))
-                .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_SNAIL.get(), 20, 1, 3))
-                .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_EEL.get(), 20, 2, 5))
-                .build();
-
-        BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
-
-        // carvers
-        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
-        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
-
-        // features: step 1 = underground ores/blobs
-        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
-//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
-//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));
-        // ... add the rest from your JSON list
-
-        Biome biome = new Biome.BiomeBuilder()
-                .temperature(0.8f)
-                .downfall(0.4f)
-                .hasPrecipitation(false)
-                .specialEffects(effects)
-                .mobSpawnSettings(spawns)
-                .generationSettings(gen.build())
-                .build();
-
-        context.register(NorthstarBiomes.LUNAR_ASURINE_CAVES, biome);
+        LunarBiomes.boostrap(context);
+        MarsBiomes.boostrap(context);
+        VenusBiomes.boostrap(context);
+        MercuryBiomes.boostrap(context);
     }
 }

--- a/src/main/java/com/lightning/northstar/data/worldgen/NorthstarBiomeProvider.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/NorthstarBiomeProvider.java
@@ -1,0 +1,60 @@
+package com.lightning.northstar.data.worldgen;
+
+import com.lightning.northstar.content.NorthstarBiomes;
+import com.lightning.northstar.content.NorthstarEntityTypes;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.data.worldgen.Carvers;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+
+public class NorthstarBiomeProvider {
+
+    public static void bootstrap(BootstapContext<Biome> context) {
+        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+        HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
+
+        BiomeSpecialEffects effects = new BiomeSpecialEffects.Builder()
+                .skyColor(0)
+                .fogColor(0)
+                .waterColor(4159204)
+                .waterFogColor(329011)
+                .build();
+
+        MobSpawnSettings spawns = new MobSpawnSettings.Builder()
+                .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_LUNARGRADE.get(), 40, 1, 4))
+                .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_SNAIL.get(), 20, 1, 3))
+                .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_EEL.get(), 20, 2, 5))
+                .build();
+
+        BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
+
+        // carvers
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
+
+        // features: step 1 = underground ores/blobs
+        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));
+        // ... add the rest from your JSON list
+
+        Biome biome = new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects)
+                .mobSpawnSettings(spawns)
+                .generationSettings(gen.build())
+                .build();
+
+        context.register(NorthstarBiomes.LUNAR_ASURINE_CAVES, biome);
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/NorthstarConfiguredFeatures.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/NorthstarConfiguredFeatures.java
@@ -1,4 +1,4 @@
-package com.lightning.northstar.data;
+package com.lightning.northstar.data.worldgen;
 
 import com.lightning.northstar.Northstar;
 import com.lightning.northstar.content.NorthstarBlocks;
@@ -34,6 +34,7 @@ import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvi
 
 import java.util.Optional;
 
+
 public class NorthstarConfiguredFeatures {
 
     public static final ResourceKey<ConfiguredFeature<?, ?>> COILER = ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("coiler"));
@@ -54,9 +55,97 @@ public class NorthstarConfiguredFeatures {
     public static final ResourceKey<ConfiguredFeature<?, ?>> GLOWSTONE_BRANCH = ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("glowstone_branch"));
     public static final ResourceKey<ConfiguredFeature<?, ?>> GLOWSTONE_UPSIDE_DOWN_BRANCH = ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("glowstone_upside_down_branch"));
 
+    //Ores (I am trying to streamline this so adding new ores to all planets is as simple as possible)
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_COPPER =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_copper_ore"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_COPPER_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_copper_ore_large"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_DIAMOND =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_diamond"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_GLOWSTONE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_glowstone"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_GOLD =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_gold"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_IRON =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_iron"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_IRON_SMALL =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_iron_small"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_IRON_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_iron_large"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_LAPIS =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_lapis"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_REDSTONE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_redstone"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_TITANIUM =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_titanium"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_ZINC =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_zinc"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MOON_ORE_ZINC_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("moon_ore_zinc_large"));
+//
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_COPPER =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_copper_ore"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_COPPER_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_copper_ore_large"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_IRON =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_iron"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_IRON_SMALL =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_iron_small"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_LAPIS =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_lapis"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_REDSTONE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_redstone"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_TITANIUM =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_titanium"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_ZINC =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_zinc"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MARS_ORE_ZINC_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mars_ore_zinc_large"));
+//
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_COPPER =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_copper_ore"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_COPPER_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_copper_ore_large"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_IRON =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_iron"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_IRON_SMALL =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_iron_small"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_LAPIS =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_lapis"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_REDSTONE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_redstone"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_TITANIUM =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_titanium"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_ZINC =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_zinc"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> MERCURY_ORE_ZINC_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("mercury_ore_zinc_large"));
+//
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_COPPER =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_copper_ore"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_COPPER_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_copper_ore_large"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_IRON =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_iron"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_IRON_SMALL =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_iron_small"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_LAPIS =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_lapis"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_REDSTONE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_redstone"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_TITANIUM =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_titanium"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_ZINC =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_zinc"));
+//    public static final ResourceKey<ConfiguredFeature<?, ?>> VENUS_ORE_ZINC_LARGE =
+//            ResourceKey.create(Registries.CONFIGURED_FEATURE, Northstar.asResource("venus_ore_zinc_large"));
+
+
     @SuppressWarnings("unchecked")
     public static void bootstrap(BootstapContext<ConfiguredFeature<?, ?>> context) {
         HolderGetter<Block> block = context.lookup(Registries.BLOCK);
+
+       PlanetOres.bootstrapConfiguredFeatures(context);
 
         context.register(COILER, new ConfiguredFeature<>(Feature.TREE,
                 new TreeConfiguration.TreeConfigurationBuilder(

--- a/src/main/java/com/lightning/northstar/data/worldgen/NorthstarPlacedFeatures.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/NorthstarPlacedFeatures.java
@@ -1,0 +1,50 @@
+package com.lightning.northstar.data.worldgen;
+
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.placement.*;
+
+public class NorthstarPlacedFeatures {
+
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_COPPER =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_copper_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_DIAMOND =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_diamond_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_GLOWSTONE =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_glowstone_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_GOLD =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_gold_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_IRON_SMALL =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_iron_ore_small"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_IRON_LARGE =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_iron_ore_large"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_LAPIS =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_lapis_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_REDSTONE =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_redstone_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_TITANIUM =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_titanium_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_ZINC =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_zinc_ore"));
+//
+//    public static final ResourceKey<PlacedFeature> MOON_ORE_ZINC_LARGE =
+//            ResourceKey.create(Registries.PLACED_FEATURE, Northstar.asResource("moon_zinc_ore_large"));
+
+
+    public static void bootstrap(BootstapContext<PlacedFeature> context) {
+        HolderGetter<ConfiguredFeature<?, ?>> configured = context.lookup(Registries.CONFIGURED_FEATURE);
+
+        PlanetOres.bootstrapPlacedFeatures(configured, context);
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/PlanetOre.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/PlanetOre.java
@@ -1,0 +1,52 @@
+package com.lightning.northstar.data.worldgen;
+
+import com.lightning.northstar.Northstar;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.placement.*;
+
+import java.util.List;
+
+public class PlanetOre {
+    private final OreConfiguration oreConfiguration;
+    private final List<PlacementModifier> placementModifiers;
+    public final ResourceKey<ConfiguredFeature<?, ?>> configuredFeature;
+    public final ResourceKey<PlacedFeature> placedFeature;
+
+    public PlanetOre(ResourceLocation resourceKey,
+                     OreConfiguration oreConfiguration,
+                     List<PlacementModifier> placementModifiers) {
+
+        this.oreConfiguration = oreConfiguration;
+        this.placementModifiers = placementModifiers;
+
+        configuredFeature = ResourceKey.create(Registries.CONFIGURED_FEATURE, resourceKey);
+        placedFeature = ResourceKey.create(Registries.PLACED_FEATURE, resourceKey);
+    }
+
+    /**
+     * Register configured feature
+     *
+     * @param context
+     */
+    public void bootstrapConfiguredFeature(BootstapContext<ConfiguredFeature<?, ?>> context) {
+        context.register(configuredFeature, new ConfiguredFeature<>(Feature.ORE, oreConfiguration));
+    }
+
+    /**
+     * Register placed feature
+     * MUST be called after configured feature is registered
+     *
+     * @param context
+     * @param configured
+     */
+    public void bootstrapPlacedFeature(BootstapContext<PlacedFeature> context, HolderGetter<ConfiguredFeature<?, ?>> configured) {
+        context.register(placedFeature, new PlacedFeature(configured.getOrThrow(configuredFeature), placementModifiers));
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/PlanetOres.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/PlanetOres.java
@@ -1,0 +1,105 @@
+package com.lightning.northstar.data.worldgen;
+
+import com.lightning.northstar.Northstar;
+import com.lightning.northstar.content.NorthstarBlocks;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.heightproviders.TrapezoidHeight;
+import net.minecraft.world.level.levelgen.placement.*;
+import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
+
+import java.util.List;
+
+public class PlanetOres {
+
+    /**
+     * The moon
+     */
+    private final static TagMatchTest moonStoneReplaceable = new TagMatchTest(BlockTags.create(Northstar.asResource("moon_stone_replaceable")));
+    private final static TagMatchTest moonDeepStoneReplaceable = new TagMatchTest(BlockTags.create(Northstar.asResource("moon_deep_stone_replaceable")));
+
+    private final static List<OreConfiguration.TargetBlockState> moonCopperBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_COPPER_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_COPPER_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonDiamondBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_DIAMOND_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_DIAMOND_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonGlowstoneBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_GLOWSTONE_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_GLOWSTONE_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonGoldBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_GOLD_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_GOLD_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonIronBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_IRON_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_IRON_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonIronSmallBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_IRON_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonLapisBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_LAPIS_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_LAPIS_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonRedstoneBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_REDSTONE_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_REDSTONE_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonTitaniumBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_TITANIUM_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_TITANIUM_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonZincBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_ZINC_ORE.get().defaultBlockState()),
+            OreConfiguration.target(moonDeepStoneReplaceable, NorthstarBlocks.MOON_DEEP_ZINC_ORE.get().defaultBlockState())
+    );
+
+    private final static List<OreConfiguration.TargetBlockState> moonZincLargeBlock = List.of(
+            OreConfiguration.target(moonStoneReplaceable, NorthstarBlocks.MOON_ZINC_ORE.get().defaultBlockState())
+    );
+
+
+
+    public final static PlanetOre MOON_ORE_COPPER = new PlanetOre(
+            Northstar.asResource("moon_copper_ore"),
+            //Configured Feature
+            new OreConfiguration(moonCopperBlock, 4, 0.0f),
+            //Placed Feature
+            List.of(
+                    CountPlacement.of(20),  // count: 20 veins per chunk
+                    InSquarePlacement.spread(), // in_square
+                    HeightRangePlacement.of(
+                            TrapezoidHeight.of(
+                                    VerticalAnchor.absolute(-16),
+                                    VerticalAnchor.absolute(112)
+                            )
+                    ),
+                    BiomeFilter.biome())
+    );
+
+
+    public static void bootstrapConfiguredFeatures(BootstapContext<ConfiguredFeature<?, ?>> context) {
+        MOON_ORE_COPPER.bootstrapConfiguredFeature(context);
+    }
+
+    public static void bootstrapPlacedFeatures(HolderGetter<ConfiguredFeature<?, ?>> configured, BootstapContext<PlacedFeature> context) {
+        MOON_ORE_COPPER.bootstrapPlacedFeature(context, configured);
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/LunarBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/LunarBiomes.java
@@ -1,5 +1,6 @@
 package com.lightning.northstar.data.worldgen.biomes;
 
+import com.lightning.northstar.Northstar;
 import com.lightning.northstar.content.NorthstarBiomes;
 import com.lightning.northstar.content.NorthstarEntityTypes;
 import com.lightning.northstar.data.worldgen.PlanetOres;
@@ -8,6 +9,7 @@ import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstapContext;
 import net.minecraft.data.worldgen.Carvers;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.biome.*;
 import net.minecraft.world.level.levelgen.GenerationStep;
@@ -16,21 +18,21 @@ import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
 public class LunarBiomes {
 
-  private static  MobSpawnSettings spawns = new MobSpawnSettings.Builder()
+    private static MobSpawnSettings spawns = new MobSpawnSettings.Builder()
             .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_LUNARGRADE.get(), 40, 1, 4))
             .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_SNAIL.get(), 20, 1, 3))
             .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_EEL.get(), 20, 2, 5))
             .build();
 
 
-    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+    static BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
             .skyColor(0)
             .fogColor(0)
             .waterColor(4159204)
             .waterFogColor(329011)
             .build();
 
-    BiomeSpecialEffects effects2 = new BiomeSpecialEffects.Builder()
+    static BiomeSpecialEffects effects2 = new BiomeSpecialEffects.Builder()
             .skyColor(0)
             .fogColor(0)
             .waterColor(4159204)
@@ -48,16 +50,20 @@ public class LunarBiomes {
             .build();
 
 
-    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+    static private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
         HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
         HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
-        BiomeGenerationSettings.Builder    gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
+        BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
 
         // carvers
         gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
         gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
 
-        // features: step 1 = underground ores/blobs
+        // features
+        gen.addFeature(GenerationStep.Decoration.RAW_GENERATION, placedFeatures.getOrThrow(
+                ResourceKey.create(Registries.PLACED_FEATURE,Northstar.asResource("rare_lava_lake")
+                )
+        ));
         gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
 //        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
 //        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/LunarBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/LunarBiomes.java
@@ -1,0 +1,132 @@
+package com.lightning.northstar.data.worldgen.biomes;
+
+import com.lightning.northstar.content.NorthstarBiomes;
+import com.lightning.northstar.content.NorthstarEntityTypes;
+import com.lightning.northstar.data.worldgen.PlanetOres;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.data.worldgen.Carvers;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.*;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+
+public class LunarBiomes {
+
+  private static  MobSpawnSettings spawns = new MobSpawnSettings.Builder()
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_LUNARGRADE.get(), 40, 1, 4))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_SNAIL.get(), 20, 1, 3))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MOON_EEL.get(), 20, 2, 5))
+            .build();
+
+
+    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+            .skyColor(0)
+            .fogColor(0)
+            .waterColor(4159204)
+            .waterFogColor(329011)
+            .build();
+
+    BiomeSpecialEffects effects2 = new BiomeSpecialEffects.Builder()
+            .skyColor(0)
+            .fogColor(0)
+            .waterColor(4159204)
+            .waterFogColor(329011)
+//            .ambientMoodSound(new AmbientMoodSettings(
+//                    SoundEvents.AMETHYST_BLOCK_CHIME, // same as "block.amethyst_block.chime"
+//                    6000, // tick_delay
+//                    8,    // block_search_extent
+//                    2.0   // offset
+//            ))
+            .ambientParticle(new AmbientParticleSettings(
+                    new SimpleParticleType(true), // placeholder, replaced below
+                    1.0F // probability
+            ))
+            .build();
+
+
+    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+        HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
+        BiomeGenerationSettings.Builder    gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
+
+        // carvers
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
+
+        // features: step 1 = underground ores/blobs
+        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));
+        // ... add the rest from your JSON list
+        return gen;
+    }
+
+    public static void boostrap(BootstapContext<Biome> context) {
+        context.register(NorthstarBiomes.LUNAR_ASURINE_CAVES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.LUNAR_COOLED_LAVA_CAVE, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.LUNAR_CRATER_FIELDS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.LUNAR_GLOWSTONE_CAVERN, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.LUNAR_HILLS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.LUNAR_ICE_CAVES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.LUNAR_PLAINS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects2)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/MarsBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/MarsBiomes.java
@@ -23,14 +23,14 @@ public class MarsBiomes {
             .build();
 
 
-    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+    static  BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
             .skyColor(14331548)
             .fogColor(15264214)
             .waterColor(4159204)
             .waterFogColor(329011)
             .build();
 
-    BiomeSpecialEffects effects2 = new BiomeSpecialEffects.Builder()
+    static  BiomeSpecialEffects effects2 = new BiomeSpecialEffects.Builder()
             .skyColor(14331548)
             .fogColor(15264214)
             .waterColor(4159204)
@@ -50,7 +50,7 @@ public class MarsBiomes {
     }*/
 
 
-    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+    static  private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
         HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
         HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
         BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/MarsBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/MarsBiomes.java
@@ -1,0 +1,127 @@
+package com.lightning.northstar.data.worldgen.biomes;
+
+import com.lightning.northstar.content.NorthstarBiomes;
+import com.lightning.northstar.content.NorthstarEntityTypes;
+import com.lightning.northstar.data.worldgen.PlanetOres;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.data.worldgen.Carvers;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.*;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+
+public class MarsBiomes {
+
+    private static MobSpawnSettings spawns = new MobSpawnSettings.Builder()
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MARS_WORM.get(), 40, 1, 4))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MARS_COBRA.get(), 20, 1, 3))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MARS_TOAD.get(), 20, 3, 6))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MARS_MOTH.get(), 20, 1, 3))
+            .build();
+
+
+    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+            .skyColor(14331548)
+            .fogColor(15264214)
+            .waterColor(4159204)
+            .waterFogColor(329011)
+            .build();
+
+    BiomeSpecialEffects effects2 = new BiomeSpecialEffects.Builder()
+            .skyColor(14331548)
+            .fogColor(15264214)
+            .waterColor(4159204)
+            .waterFogColor(329011)
+//            .ambientParticle(new AmbientParticleSettings(
+//                    new SimpleParticleType(true), // placeholder, replaced below
+//                    0.025F // probability
+//            ))
+            .build();
+
+    /*
+    *     "particle": {
+      "options": {
+        "type": "minecraft:white_ash"
+      },
+      "probability": 0.025
+    }*/
+
+
+    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+        HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
+        BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
+
+        // carvers
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
+
+        // features: step 1 = underground ores/blobs
+        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));
+        // ... add the rest from your JSON list
+        return gen;
+    }
+
+
+    public static void boostrap(BootstapContext<Biome> context) {
+        context.register(NorthstarBiomes.MARTIAN_CRIMSITE_CAVERNS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .temperatureAdjustment(Biome.TemperatureModifier.FROZEN)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MARTIAN_DUNES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1) .temperatureAdjustment(Biome.TemperatureModifier.FROZEN)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MARTIAN_HIGH_LANDS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1) .temperatureAdjustment(Biome.TemperatureModifier.FROZEN)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MARTIAN_MAGMATIC_CAVERNS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects2) .temperatureAdjustment(Biome.TemperatureModifier.FROZEN)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MARTIAN_OVERGROWN_CAVERNS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MARTIAN_PEAKS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1) .temperatureAdjustment(Biome.TemperatureModifier.FROZEN)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/MercuryBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/MercuryBiomes.java
@@ -1,0 +1,87 @@
+package com.lightning.northstar.data.worldgen.biomes;
+
+import com.lightning.northstar.content.NorthstarBiomes;
+import com.lightning.northstar.content.NorthstarEntityTypes;
+import com.lightning.northstar.data.worldgen.PlanetOres;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.data.worldgen.Carvers;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.*;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+
+public class MercuryBiomes {
+
+    private static MobSpawnSettings spawns = new MobSpawnSettings.Builder()
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_RAPTOR.get(), 30, 1, 3))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_ROACH.get(), 30, 1, 3))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_TORTOISE.get(), 30, 2, 5))
+            .build();
+
+
+    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+            .skyColor(0)
+            .fogColor(0)
+            .waterColor(4159204)
+            .waterFogColor(329011)
+            .build();
+
+
+    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+        HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
+        BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
+
+        // carvers
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
+
+        // features: step 1 = underground ores/blobs
+        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));
+        // ... add the rest from your JSON list
+        return gen;
+    }
+
+    public static void boostrap(BootstapContext<Biome> context) {
+        context.register(NorthstarBiomes.MERCURY_HILLS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MERCURY_BASINS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MERCURY_ICY_CAVES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.MERCURY_MAGMATIC_CAVERNS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/MercuryBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/MercuryBiomes.java
@@ -17,12 +17,12 @@ public class MercuryBiomes {
 
     private static MobSpawnSettings spawns = new MobSpawnSettings.Builder()
             .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_RAPTOR.get(), 30, 1, 3))
-            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_ROACH.get(), 30, 1, 3))
-            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_TORTOISE.get(), 30, 2, 5))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_TORTOISE.get(), 30, 1, 3))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.MERCURY_ROACH.get(), 30, 2, 5))
             .build();
 
 
-    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+    static  BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
             .skyColor(0)
             .fogColor(0)
             .waterColor(4159204)
@@ -30,7 +30,7 @@ public class MercuryBiomes {
             .build();
 
 
-    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+    static  private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
         HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
         HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
         BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/VenusBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/VenusBiomes.java
@@ -1,0 +1,105 @@
+package com.lightning.northstar.data.worldgen.biomes;
+
+import com.lightning.northstar.content.NorthstarBiomes;
+import com.lightning.northstar.content.NorthstarEntityTypes;
+import com.lightning.northstar.data.worldgen.PlanetOres;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstapContext;
+import net.minecraft.data.worldgen.Carvers;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.*;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+
+public class VenusBiomes {
+
+    private static MobSpawnSettings spawns = new MobSpawnSettings.Builder()
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.VENUS_MIMIC.get(), 40, 1, 4))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.VENUS_SCORPION.get(), 20, 1, 3))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.VENUS_VULTURE.get(), 20, 2, 5))
+            .addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(NorthstarEntityTypes.VENUS_STONE_BULL.get(), 20, 2, 5))
+            .build();
+
+
+    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+            .skyColor(14543991)
+            .fogColor(14538752)
+            .waterColor(4159204)
+            .waterFogColor(329011)
+            .build();
+
+    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+        HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
+        BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);
+
+        // carvers
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE));
+        gen.addCarver(GenerationStep.Carving.AIR, carvers.getOrThrow(Carvers.CAVE_EXTRA_UNDERGROUND));
+
+        // features: step 1 = underground ores/blobs
+        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(PlanetOres.MOON_ORE_COPPER.placedFeature));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_TITANIUM));
+//        gen.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, placedFeatures.getOrThrow(NorthstarPlacedFeatures.MOON_ORE_DIAMOND));
+        // ... add the rest from your JSON list
+        return gen;
+    }
+
+    public static void boostrap(BootstapContext<Biome> context) {
+        context.register(NorthstarBiomes.VENUS_FUNGAL_FOREST, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.VENUS_FUNGAL_CAVES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.VENUS_SULFURIC_CAVERNS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.VENUS_LAVA_CAVES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.VENUSIAN_PLAINS, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+
+        context.register(NorthstarBiomes.VENUSIAN_WASTES, new Biome.BiomeBuilder()
+                .temperature(0.8f)
+                .downfall(0.4f)
+                .hasPrecipitation(false)
+                .specialEffects(effects1)
+                .mobSpawnSettings(spawns)
+                .generationSettings(generatorSettings(context).build())
+                .build());
+    }
+}

--- a/src/main/java/com/lightning/northstar/data/worldgen/biomes/VenusBiomes.java
+++ b/src/main/java/com/lightning/northstar/data/worldgen/biomes/VenusBiomes.java
@@ -23,14 +23,14 @@ public class VenusBiomes {
             .build();
 
 
-    BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
+    static BiomeSpecialEffects effects1 = new BiomeSpecialEffects.Builder()
             .skyColor(14543991)
             .fogColor(14538752)
             .waterColor(4159204)
             .waterFogColor(329011)
             .build();
 
-    private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
+    static private BiomeGenerationSettings.Builder generatorSettings(BootstapContext<Biome> context) {
         HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
         HolderGetter<ConfiguredWorldCarver<?>> carvers = context.lookup(Registries.CONFIGURED_CARVER);
         BiomeGenerationSettings.Builder gen = new BiomeGenerationSettings.Builder(placedFeatures, carvers);

--- a/src/main/java/com/lightning/northstar/world/features/grower/ArgyreCeilingTreeGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/ArgyreCeilingTreeGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/ArgyreSaplingTreeGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/ArgyreSaplingTreeGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/ArgyreTreeGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/ArgyreTreeGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/CoilerTreeGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/CoilerTreeGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/MercuryCactusGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/MercuryCactusGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/SpikeFungusGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/SpikeFungusGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/TestTreeGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/TestTreeGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;

--- a/src/main/java/com/lightning/northstar/world/features/grower/WilterTreeGrower.java
+++ b/src/main/java/com/lightning/northstar/world/features/grower/WilterTreeGrower.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.world.features.grower;
 
-import com.lightning.northstar.data.NorthstarConfiguredFeatures;
+import com.lightning.northstar.data.worldgen.NorthstarConfiguredFeatures;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;


### PR DESCRIPTION
Adding datagen fore ores is essential for adding new ores easily. The goal is to make the process of adding 1 new ore to multiple planets as simple as possible.