### PR TITLE
Do not require CreateJS for the built-in plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,8 +137,8 @@ dependencies {
     modImplementation(libs.cdg)
     modImplementation(libs.cca)
     modImplementation(libs.kubejs)
-    modImplementation(libs.kubejs.create)
     forgeRuntimeLibrary("dev.latvian.apps:tiny-java-server:1.0.0-build.26")
+
     modImplementation(libs.tfmg)
 
     // Embeddium and Oculus have to be installed manually on the client as not to crash the server. keep jCPP as oculus crashes without it.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ geckolib-neoforge = "software.bernie.geckolib:geckolib-neoforge-1.21.1:4.7.2"
 jcpp = "org.anarres:jcpp:1.4.14"
 jei-neoforge = "mezz.jei:jei-1.21.1-neoforge:19.25.0.322"
 kubejs = "dev.latvian.mods:kubejs-neoforge:2101.7.2-build.285"
-kubejs-create = "maven.modrinth:kubejs-create:2101.3.1-build.18"
 mclib = "com.eliotlash.mclib:mclib:20"
 minecraft = "com.mojang:minecraft:1.21.1"
 mixinextras-common = { module = "io.github.llamalad7:mixinextras-common", version.ref = "mixinextras" }

--- a/src/main/java/com/lightning/northstar/compat/kubejs/component/CreateRecipeComponents.java
+++ b/src/main/java/com/lightning/northstar/compat/kubejs/component/CreateRecipeComponents.java
@@ -1,0 +1,14 @@
+package com.lightning.northstar.compat.kubejs.component;
+
+import com.simibubi.create.Create;
+import com.simibubi.create.content.processing.recipe.HeatCondition;
+import com.simibubi.create.foundation.codec.CreateCodecs;
+import dev.latvian.mods.kubejs.recipe.component.EnumComponent;
+import dev.latvian.mods.kubejs.recipe.component.RecipeComponentType;
+import dev.latvian.mods.kubejs.recipe.component.SizedFluidIngredientComponent;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
+
+public interface CreateRecipeComponents {
+    RecipeComponentType<HeatCondition> HEAT_CONDITION = EnumComponent.of(Create.asResource("heat_condition"), HeatCondition.class, HeatCondition.CODEC);
+    RecipeComponentType<SizedFluidIngredient> SIZED_FLUID_INGREDIENT = RecipeComponentType.unit(Create.asResource("sized_fluid_ingredient"), (type) -> new SizedFluidIngredientComponent(type, CreateCodecs.FLAT_SIZED_FLUID_INGREDIENT_WITH_TYPE, false));
+}

--- a/src/main/java/com/lightning/northstar/compat/kubejs/component/KubeCreateOutput.java
+++ b/src/main/java/com/lightning/northstar/compat/kubejs/component/KubeCreateOutput.java
@@ -1,0 +1,55 @@
+package com.lightning.northstar.compat.kubejs.component;
+
+import com.google.gson.JsonObject;
+import com.simibubi.create.content.processing.recipe.ProcessingOutput;
+import dev.latvian.mods.kubejs.plugin.builtin.wrapper.ItemWrapper;
+import dev.latvian.mods.kubejs.plugin.builtin.wrapper.StringUtilsWrapper;
+import dev.latvian.mods.rhino.Context;
+import dev.latvian.mods.rhino.util.HideFromJS;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.ItemLike;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public interface KubeCreateOutput {
+    @Contract("_ -> new")
+    static @NotNull ProcessingOutput of(ItemStack stack) {
+        return new ProcessingOutput(stack, 1F);
+    }
+
+    @Contract("_, _ -> new")
+    static @NotNull ProcessingOutput of(ItemStack stack, double c) {
+        var chance = (float) Mth.clamp(c, 0.0, 1.0);
+        return new ProcessingOutput(stack, chance);
+    }
+
+    private static @NotNull ProcessingOutput fromMapLike(Context cx, Object from, @NotNull Function<String, Object> getter, boolean nested) {
+        var chance = (float) Mth.clamp(StringUtilsWrapper.parseDouble(getter.apply("chance"), 1.0), 0.0, 1.0);
+        if (nested) {
+            var output = ItemWrapper.wrap(cx, getter.apply("output"));
+            return new ProcessingOutput(output, chance);
+        } else {
+            return new ProcessingOutput(ItemWrapper.wrap(cx, from), chance);
+        }
+    }
+
+    @HideFromJS
+    static ProcessingOutput wrapProcessingOutput(Context cx, @Nullable Object from) {
+        return switch (from) {
+            case null -> ProcessingOutput.EMPTY;
+            case ProcessingOutput id -> id;
+            case ItemStack s -> s.isEmpty() ? ProcessingOutput.EMPTY : new ProcessingOutput(s, 1F);
+            case ItemLike i when i.asItem() == Items.AIR -> ProcessingOutput.EMPTY;
+            case ItemLike i -> new ProcessingOutput(i.asItem(), 1, 1F);
+            case JsonObject json when json.has("chance") -> fromMapLike(cx, json, json::get, json.has("output"));
+            case Map<?, ?> map when map.containsKey("chance") -> fromMapLike(cx, map, map::get, map.containsKey("output"));
+            default -> new ProcessingOutput(ItemWrapper.wrap(cx, from), 1F);
+        };
+    }
+}

--- a/src/main/java/com/lightning/northstar/compat/kubejs/component/ProcessingOutputRecipeComponent.java
+++ b/src/main/java/com/lightning/northstar/compat/kubejs/component/ProcessingOutputRecipeComponent.java
@@ -1,0 +1,68 @@
+package com.lightning.northstar.compat.kubejs.component;
+
+import com.simibubi.create.Create;
+import com.simibubi.create.content.processing.recipe.ProcessingOutput;
+import dev.latvian.mods.kubejs.plugin.builtin.wrapper.ItemWrapper;
+import dev.latvian.mods.kubejs.recipe.RecipeScriptContext;
+import dev.latvian.mods.kubejs.recipe.component.RecipeComponentType;
+import dev.latvian.mods.kubejs.recipe.component.SimpleRecipeComponent;
+import dev.latvian.mods.kubejs.recipe.component.UniqueIdBuilder;
+import dev.latvian.mods.kubejs.recipe.filter.RecipeMatchContext;
+import dev.latvian.mods.kubejs.recipe.match.ItemMatch;
+import dev.latvian.mods.kubejs.recipe.match.ReplacementMatchInfo;
+import dev.latvian.mods.rhino.type.TypeInfo;
+import net.minecraft.world.item.ItemStack;
+
+public class ProcessingOutputRecipeComponent extends SimpleRecipeComponent<ProcessingOutput> {
+    public static final TypeInfo TYPE_INFO = TypeInfo.of(ProcessingOutput.class);
+    public static final RecipeComponentType<ProcessingOutput> TYPE = RecipeComponentType.unit(Create.asResource("processing_output"), ProcessingOutputRecipeComponent::new);
+
+    public ProcessingOutputRecipeComponent(RecipeComponentType<?> type) {
+        super(type, ProcessingOutput.CODEC_NEW, TYPE_INFO);
+    }
+
+    @Override
+    public boolean hasPriority(RecipeMatchContext cx, Object from) {
+        return from instanceof ProcessingOutput || ItemWrapper.isItemStackLike(from);
+    }
+
+    @Override
+    public boolean matches(RecipeMatchContext cx, ProcessingOutput value, ReplacementMatchInfo match) {
+        return match.match() instanceof ItemMatch m && m.matches(cx, value.getStack(), match.exact());
+    }
+
+    @Override
+    public ProcessingOutput replace(RecipeScriptContext cx, ProcessingOutput original, ReplacementMatchInfo match, Object with) {
+        if (matches(cx, original, match)) {
+            return switch (with) {
+                case ProcessingOutput output -> output;
+                case ItemStack stack -> new ProcessingOutput(stack, original.getChance());
+                default -> {
+                    var output = KubeCreateOutput.wrapProcessingOutput(cx.cx(), with);
+
+                    if (output != ProcessingOutput.EMPTY &&
+                            !(ItemStack.isSameItemSameComponents(output.getStack(), original.getStack()))) {
+                        yield new ProcessingOutput(output.getStack(), original.getChance());
+                    }
+
+                    yield original;
+                }
+            };
+        }
+
+        return original;
+    }
+
+    @Override
+    public boolean isEmpty(ProcessingOutput value) {
+        return value == ProcessingOutput.EMPTY || value.getStack().isEmpty();
+    }
+
+    @Override
+    @SuppressWarnings("deprecated")
+    public void buildUniqueId(UniqueIdBuilder builder, ProcessingOutput value) {
+        if (!isEmpty(value)) {
+            builder.append(value.getStack().getItem().builtInRegistryHolder().getKey().location());
+        }
+    }
+}

--- a/src/main/java/com/lightning/northstar/compat/kubejs/recipe/ElectrolysisRecipeSchema.java
+++ b/src/main/java/com/lightning/northstar/compat/kubejs/recipe/ElectrolysisRecipeSchema.java
@@ -1,6 +1,6 @@
 package com.lightning.northstar.compat.kubejs.recipe;
 
-import dev.latvian.mods.kubejs.create.recipe.CreateRecipeComponents;
+import com.lightning.northstar.compat.kubejs.component.CreateRecipeComponents;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.component.FluidStackComponent;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;

--- a/src/main/java/com/lightning/northstar/compat/kubejs/recipe/EngravingRecipeSchema.java
+++ b/src/main/java/com/lightning/northstar/compat/kubejs/recipe/EngravingRecipeSchema.java
@@ -1,7 +1,7 @@
 package com.lightning.northstar.compat.kubejs.recipe;
 
+import com.lightning.northstar.compat.kubejs.component.ProcessingOutputRecipeComponent;
 import com.simibubi.create.content.processing.recipe.ProcessingOutput;
-import dev.latvian.mods.kubejs.create.recipe.ProcessingOutputRecipeComponent;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.component.IngredientComponent;
 import dev.latvian.mods.kubejs.recipe.component.TimeComponent;
@@ -14,7 +14,7 @@ import java.util.List;
 public interface EngravingRecipeSchema {
 
     RecipeKey<List<Ingredient>> INGREDIENTS = IngredientComponent.INGREDIENT.instance().asList().inputKey("ingredients");
-    RecipeKey<List< ProcessingOutput>> RESULTS = ProcessingOutputRecipeComponent.TYPE.instance().asList().outputKey("results");
+    RecipeKey<List<ProcessingOutput>> RESULTS = ProcessingOutputRecipeComponent.TYPE.instance().asList().outputKey("results");
     RecipeKey<TickDuration> TIME = TimeComponent.TICKS.inputKey("processingTime").optional(TickDuration.of(100L));
 
     RecipeSchema SCHEMA = new RecipeSchema(RESULTS, INGREDIENTS, TIME);

--- a/src/main/java/com/lightning/northstar/compat/kubejs/recipe/NorthstarComponents.java
+++ b/src/main/java/com/lightning/northstar/compat/kubejs/recipe/NorthstarComponents.java
@@ -1,9 +1,9 @@
 package com.lightning.northstar.compat.kubejs.recipe;
 
+import com.lightning.northstar.compat.kubejs.component.CreateRecipeComponents;
+import com.lightning.northstar.compat.kubejs.component.ProcessingOutputRecipeComponent;
 import com.mojang.datafixers.util.Either;
 import com.simibubi.create.content.processing.recipe.ProcessingOutput;
-import dev.latvian.mods.kubejs.create.recipe.CreateRecipeComponents;
-import dev.latvian.mods.kubejs.create.recipe.ProcessingOutputRecipeComponent;
 import dev.latvian.mods.kubejs.recipe.component.FluidStackComponent;
 import dev.latvian.mods.kubejs.recipe.component.IngredientComponent;
 import dev.latvian.mods.kubejs.recipe.component.ListRecipeComponent;

--- a/src/main/resources/kubejs.plugins.txt
+++ b/src/main/resources/kubejs.plugins.txt
@@ -1,1 +1,1 @@
-com.lightning.northstar.compat.kubejs.NorthstarKubeJsPlugin
+com.lightning.northstar.compat.kubejs.NorthstarKubeJsPlugin northstar


### PR DESCRIPTION
This removes an unnecessary dependency (and other create kube addons do the same thing), and has it all built in.

Other mods do this way as well, and this also help prevent errors within kube (Datapack errors, see #67)